### PR TITLE
chore: bump version to 1.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ubiquibot/permit-generation",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "description": "ECR20 / ECR721 permit generation for automated payments.",
   "author": "Ubiquity DAO",
   "license": "MIT",


### PR DESCRIPTION
Somehow `release-please` downgraded the version from `1.2.2` to `1.0.0` [here](https://github.com/ubiquibot/permit-generation/pull/23) instead of bumping to `1.3.0`.

This PR bumps the version to `1.3.0` manually. The next step is to merge the `development` branch into `main` to publish a new package version to npm.