### PR TITLE
ci: build project on NPM publish

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -26,6 +26,7 @@ jobs:
           registry-url: https://registry.npmjs.org/
       - run: |
           yarn install --immutable --immutable-cache --check-cache
+          yarn build
           yarn pack
           yarn publish --access public
         env:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ubiquibot/permit-generation",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "ECR20 / ECR721 permit generation for automated payments.",
   "author": "Ubiquity DAO",
   "license": "MIT",


### PR DESCRIPTION
Somehow the latest package version `1.3.0` doesn't have the `dist` folder in the published npm package.

As far as I understand it happens because the build step is missing on publishing the package.

This PR:
1. Runs `yarn build` on NPM publish
2. Bumps version to `1.3.1` 