### PR TITLE
fix: main entry for error free imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,9 +96,9 @@
     "README.md",
     "package.json"
   ],
-  "module": "core/index.esm.js",
-  "main": "core/index.js",
-  "typings": "types/index.d.ts",
+  "module": "dist/core/index.esm.js",
+  "main": "dist/core/index.js",
+  "typings": "dist/types/index.d.ts",
   "exports": {
     "./core": {
       "require": "./dist/core/index.js",


### PR DESCRIPTION
Resolves https://github.com/ubiquibot/permit-generation/issues/41

This does prevent the usage of `../core/` or `../types/` but seeing as the main entry was `core` which includes everything anyway and was the previous default it seems like this is irrelevant?

QA:

![image](https://github.com/user-attachments/assets/f52bcdfa-cc7b-470c-af07-f1149fca35d0)

