### PR TITLE
build: export utils

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "dist/types/*",
     "dist/handlers/*",
     "dist/core/*",
+    "dist/utils/*",
     "README.md",
     "package.json"
   ],
@@ -114,6 +115,11 @@
       "require": "./dist/handlers/index.js",
       "import": "./dist/handlers/index.js",
       "types": "./dist/handlers/index.d.ts"
+    },
+    "./utils": {
+      "require": "./dist/utils/index.js",
+      "import": "./dist/utils/index.js",
+      "types": "./dist/utils/index.d.ts"
     }
   }
 }

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -26,6 +26,14 @@ const config = [
     plugins: [nodeResolve({ browser: true }), commonjs(), typescript(), yaml(), json(), generateDtsBundle(), terser()],
   },
   {
+    input: "src/utils/index.ts",
+    output: {
+      dir: "dist/utils",
+      format: "cjs",
+    },
+    plugins: [nodeResolve({ browser: true }), commonjs(), typescript(), yaml(), json(), generateDtsBundle(), terser()],
+  },
+  {
     input: "src/index.ts",
     output: {
       dir: "dist/core",

--- a/src/handlers/generate-erc20-permit.ts
+++ b/src/handlers/generate-erc20-permit.ts
@@ -2,7 +2,7 @@ import { PERMIT2_ADDRESS, PermitTransferFrom, SignatureTransfer } from "@uniswap
 import { ethers, keccak256, MaxInt256, parseUnits, toUtf8Bytes } from "ethers";
 import { Context, Logger } from "../types/context";
 import { PermitReward, TokenType } from "../types";
-import { decryptKeys } from "../utils/keys";
+import { decryptKeys } from "../utils";
 import { getFastestProvider } from "../utils/get-fastest-provider";
 
 export interface Payload {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,0 +1,1 @@
+export * from './keys';


### PR DESCRIPTION
Related to https://github.com/ubiquity/ubiquibot-kernel/issues/104

This PR exports the `utils` folder and the `decryptKeys()` method needed to be used in the https://github.com/ubiquibot/conversation-rewards plugin.