### PR TITLE
ci: target `development` for releases

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - main
+      - development
 
 permissions:
   contents: write
@@ -18,7 +18,7 @@ jobs:
         id: release
         with:
           release-type: node
-          target-branch: main
+          target-branch: development
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
Original comment: https://github.com/ubiquibot/permit-generation/pull/63#issuecomment-2347331423

I still think this is not the best idea and I don't see any issues with manually merge `development` into `main` from time to time when we need a new release.
